### PR TITLE
Replace voluptuous schema validation with Pydantic

### DIFF
--- a/StudentScore/schema.py
+++ b/StudentScore/schema.py
@@ -1,126 +1,225 @@
-from voluptuous import (
-    All,
-    Any,
-    Coerce,
-    ExactSequence,
-    Match,
-    Optional,
-    Range,
-    Replace,
-    Required,
-    Schema,
-    Self,
-)
-from voluptuous.error import Invalid
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, List, Sequence, Union
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 
-class InvalidPoint(Invalid):
-    """Invalid points."""
+class CriteriaValidationError(ValueError):
+    """Raised when the grading criteria definition is invalid."""
+
+    def __init__(self, message: str, *, errors: List[Dict[str, Any]]):
+        super().__init__(message)
+        self.errors = errors
 
 
-re_percent = r"(-?\d+(?:\.\d+)?)\%"
-
-Percent = All(
-    str,
-    Match(re_percent),
-    Replace(re_percent, r"\1"),
-    Coerce(float),
-    Range(-100, 100),
-    lambda x: x / 100,
-)
+_PERCENT_PATTERN = re.compile(r"^(-?\d+(?:\.\d+)?)%$")
 
 
-class ValidPoints(object):
-    """
-    Verify the number of points given.
-    """
+def _ensure_text_or_text_list(value: Any) -> Union[str, List[str]]:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return value
+    raise TypeError("value must be a string or a list of strings")
 
-    def __call__(self, v):
-        obtained, total = v
 
-        if obtained < total < 0:
-            raise InvalidPoint(
-                (
-                    f"Given points ({obtained}) cannot be smaller "
-                    f"than available penalty ({total})."
-                )
+def _validate_pair(value: Any) -> List[Union[int, float]]:
+    if isinstance(value, tuple):
+        value = list(value)
+
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        raise TypeError("points must be provided as a two-item sequence")
+    if len(value) != 2:
+        raise ValueError("points must contain exactly two entries")
+
+    obtained, total = value
+
+    try:
+        total_value = int(total)
+    except (TypeError, ValueError):
+        raise TypeError("total points must be an integer") from None
+
+    if isinstance(obtained, str):
+        match = _PERCENT_PATTERN.fullmatch(obtained.strip())
+        if not match:
+            raise ValueError("percentage must match the form '42%' or '-10.5%'")
+        percent_value = float(match.group(1))
+        if not -100 <= percent_value <= 100:
+            raise ValueError("percentage must be between -100% and 100%")
+        obtained_value = abs(percent_value / 100.0) * total_value
+    else:
+        try:
+            obtained_value = float(obtained)
+        except (TypeError, ValueError):
+            raise TypeError("points must be numeric or a percentage string") from None
+
+    if total_value == 0:
+        raise ValueError("No points given to this criteria.")
+    if obtained_value < total_value < 0:
+        raise ValueError(
+            (
+                f"Given points ({obtained_value}) cannot be smaller "
+                f"than available penalty ({total_value})."
             )
-        if total < 0 < obtained:
-            raise InvalidPoint(
-                (
-                    f"Given points ({obtained}) cannot be bigger "
-                    f"than zero with penalty criteria ({total})."
-                )
+        )
+    if total_value < 0 < obtained_value:
+        raise ValueError(
+            (
+                f"Given points ({obtained_value}) cannot be bigger "
+                f"than zero with penalty criteria ({total_value})."
             )
-        if total > 0 > obtained:
-            raise InvalidPoint(
-                f"Given points ({obtained}) cannot be smaller than zero."
+        )
+    if total_value > 0 > obtained_value:
+        raise ValueError(
+            f"Given points ({obtained_value}) cannot be smaller than zero."
+        )
+    if obtained_value > total_value > 0:
+        raise ValueError(
+            (
+                f"Given points ({obtained_value}) cannot be greater than "
+                f"available points ({total_value})."
             )
-        if obtained > total > 0:
-            raise InvalidPoint(
-                (
-                    f"Given points ({obtained}) cannot be greater than "
-                    f"available points ({total})."
-                )
-            )
-        if total == 0:
-            raise InvalidPoint("No points given to this criteria.")
+        )
 
-        return v
+    return [float(obtained_value), total_value]
 
 
-Pair = All(
-    Any(
-        ExactSequence([Any(int, float), int]),
-        All(ExactSequence([Percent, int]), lambda x: [abs(x[0]) * x[1], x[1]]),
-    ),
-    ValidPoints(),
-)
+class ItemModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
-DescriptionKey = Any("$description", "$desc")
+    description: Union[str, List[str]] | None = Field(default=None, alias="$description")
+    desc: Union[str, List[str]] | None = Field(default=None, alias="$desc")
+    points: List[Union[int, float]] | None = Field(default=None, alias="$points")
+    bonus: List[Union[int, float]] | None = Field(default=None, alias="$bonus")
+    rationale: Union[str, List[str]] | None = Field(default=None, alias="$rationale")
+    test: str | None = Field(default=None, alias="$test")
 
-Section = Schema(
-    {
-        Optional(DescriptionKey): str,
-        Coerce(str): Any(
-            {
-                Required(Any("$points", "$bonus")): Pair,
-                Required(DescriptionKey): Any(str, [str]),
-                Optional("$rationale"): Any(str, [str]),
-                Optional("$test"): str,
-            },
-            Self,
-        ),
-    }
-)
+    @field_validator("description", "desc", "rationale", mode="before")
+    @classmethod
+    def validate_text_block(cls, value: Any) -> Any:
+        if value is None:
+            return value
+        return _ensure_text_or_text_list(value)
 
-Criteria = Schema(Section)
+    @field_validator("points", "bonus", mode="before")
+    @classmethod
+    def validate_pair(cls, value: Any) -> Any:
+        if value is None:
+            return value
+        return _validate_pair(value)
+
+    @model_validator(mode="after")
+    def ensure_required_fields(self) -> "ItemModel":
+        if self.description is None and self.desc is None:
+            raise ValueError("either $description or $desc must be provided")
+        if self.points is None and self.bonus is None:
+            raise ValueError("either $points or $bonus must be provided")
+        return self
+
+    def as_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {}
+        if self.description is not None:
+            data["$description"] = self.description
+        if self.desc is not None:
+            data["$desc"] = self.desc
+        if self.points is not None:
+            data["$points"] = self.points
+        if self.bonus is not None:
+            data["$bonus"] = self.bonus
+        if self.rationale is not None:
+            data["$rationale"] = self.rationale
+        if self.test is not None:
+            data["$test"] = self.test
+        return data
 
 
-# class Validate:
-#     """ Validate schema. """
+class SectionModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
 
-#     def __init__(self, stream):
-#         self._yaml = yaml.load(stream, Loader=yaml.FullLoader)
-#         return self.validate()
+    description: str | None = Field(default=None, alias="$description")
+    desc: str | None = Field(default=None, alias="$desc")
+    items: Dict[str, Union["SectionModel", ItemModel]] = Field(default_factory=dict)
 
-#     def validate(self):
-#         """ Validate schema. """
-#         try:
-#             self.data = Criteria(self._yaml)
-#         except Invalid as exept:
-#             path = '/'.join(exept.path)
-#             try:
-#                 node = self._yaml
-#                 for key in exept.path:
-#                     if (hasattr(node[key], '_yaml_line_col')):
-#                         node = node[key]
-#                     else:
-#                         break
-#                 print(f"Error: validation failed on line"
-#                       f"{node._yaml_line_col.line}:"
-#                       f"{node._yaml_line_col.col} (/{path}): {exept.error_message}")
-#             except Exception as ex:
-#                 print(ex)
+    @model_validator(mode="before")
+    @classmethod
+    def restructure(cls, value: Any) -> Dict[str, Any]:
+        if not isinstance(value, dict):
+            raise TypeError("section entries must be mappings")
 
-#         return self.data
+        items: Dict[str, Any] = {}
+        data: Dict[str, Any] = {}
+        for key, item in value.items():
+            if key in {"$description", "$desc"}:
+                data[key] = item
+            else:
+                items[str(key)] = item
+        data["items"] = items
+        return data
+
+    @field_validator("description", "desc", mode="before")
+    @classmethod
+    def ensure_text(cls, value: Any) -> Any:
+        if value is None or isinstance(value, str):
+            return value
+        raise TypeError("section descriptions must be strings")
+
+    @field_validator("items", mode="before")
+    @classmethod
+    def ensure_mapping(cls, value: Any) -> Dict[str, Any]:
+        if not isinstance(value, dict):
+            raise TypeError("section items must be a mapping of criteria")
+        return value
+
+    @model_validator(mode="after")
+    def ensure_description_choice(self) -> "SectionModel":
+        if self.description is not None and self.desc is not None:
+            raise ValueError("use either $description or $desc, not both")
+        return self
+
+    def as_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {}
+        if self.description is not None:
+            data["$description"] = self.description
+        if self.desc is not None:
+            data["$desc"] = self.desc
+        for key, value in self.items.items():
+            if isinstance(value, SectionModel):
+                data[key] = value.as_dict()
+            else:
+                data[key] = value.as_dict()
+        return data
+
+
+class CriteriaModel(BaseModel):
+    criteria: SectionModel
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"criteria": self.criteria.as_dict()}
+
+
+def _format_location(parts: Iterable[Any]) -> str:
+    filtered = [str(part) for part in parts if part not in {"items"}]
+    return "/".join(filtered) if filtered else "<root>"
+
+
+def _format_validation_errors(errors: List[Dict[str, Any]]) -> str:
+    lines = ["Invalid criteria definition detected:"]
+    for error in errors:
+        location = _format_location(error.get("loc", ()))
+        message = error.get("msg", "unknown validation error")
+        lines.append(f"- {location}: {message}")
+    return "\n".join(lines)
+
+
+def Criteria(data: Any) -> Dict[str, Any]:
+    try:
+        model = CriteriaModel.model_validate(data)
+    except ValidationError as exc:
+        message = _format_validation_errors(exc.errors())
+        raise CriteriaValidationError(message, errors=exc.errors()) from exc
+    return model.as_dict()
+
+
+__all__ = ["Criteria", "CriteriaValidationError"]

--- a/StudentScore/schema.py
+++ b/StudentScore/schema.py
@@ -140,7 +140,7 @@ class SectionModel(BaseModel):
 
     description: str | None = Field(default=None, alias="$description")
     desc: str | None = Field(default=None, alias="$desc")
-    items: Dict[str, Union["SectionModel", ItemModel]] = Field(default_factory=dict)
+    items: Dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="before")
     @classmethod
@@ -176,7 +176,7 @@ class SectionModel(BaseModel):
     @field_validator("items", mode="after")
     @classmethod
     def coerce_items(
-        cls, value: Dict[str, Union["SectionModel", ItemModel, Any]]
+        cls, value: Dict[str, Any]
     ) -> Dict[str, Union["SectionModel", ItemModel]]:
         coerced: Dict[str, Union[SectionModel, ItemModel]] = {}
         for key, item in value.items():

--- a/StudentScore/schema.py
+++ b/StudentScore/schema.py
@@ -199,8 +199,8 @@ class SectionModel(BaseModel):
                             loc += tuple(error["loc"])
                         augmented_errors.append({**error, "loc": loc})
 
-                    raise ValidationError.from_exception_data(  # type: ignore[call-arg]
-                        target_model.__name__, errors=augmented_errors
+                    raise ValidationError.from_exception_data(
+                        target_model.__name__, augmented_errors
                     ) from exc
             else:
                 raise TypeError("criteria entries must be mappings")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ packages = [{ include = "StudentScore" }]
 
 [tool.poetry.dependencies]
 python = "^3.10"
-voluptuous = ">=0.12.0"
+pydantic = ">=2.7,<3.0"
 click = ">=8.0.0"
 pyyaml = ">=6.0"
 colorama = ">=0.4.0"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -68,3 +68,92 @@ class TestCriteria(TestCase):
                     }
                 }
             )
+
+    def test_sequence_type_error(self):
+        with self.assertRaises(CriteriaValidationError) as exc:
+            Criteria(
+                {
+                    "criteria": {
+                        "test": {"$description": "Description", "$points": "invalid"}
+                    }
+                }
+            )
+        self.assertIn("points must be provided as a two-item sequence", str(exc.exception))
+
+    def test_sequence_length_error(self):
+        with self.assertRaises(CriteriaValidationError):
+            Criteria(
+                {
+                    "criteria": {
+                        "test": {"$description": "Description", "$points": [1, 2, 3]}
+                    }
+                }
+            )
+
+    def test_tuple_points_are_accepted(self):
+        Criteria(
+            {
+                "criteria": {
+                    "test": {"$description": "Description", "$points": (1, 5)}
+                }
+            }
+        )
+
+    def test_percentage_format_error(self):
+        with self.assertRaises(CriteriaValidationError):
+            Criteria(
+                {
+                    "criteria": {
+                        "test": {"$description": "Description", "$points": ["bad", 5]}
+                    }
+                }
+            )
+
+    def test_percentage_bounds_error(self):
+        with self.assertRaises(CriteriaValidationError):
+            Criteria(
+                {
+                    "criteria": {
+                        "test": {"$description": "Description", "$points": ["150%", 5]}
+                    }
+                }
+            )
+
+    def test_requires_textual_description(self):
+        with self.assertRaises(CriteriaValidationError):
+            Criteria(
+                {
+                    "criteria": {
+                        "$description": ["not", "valid"],
+                        "test": {"$description": "Description", "$points": [1, 5]},
+                    }
+                }
+            )
+
+    def test_description_choice(self):
+        with self.assertRaises(CriteriaValidationError):
+            Criteria(
+                {
+                    "criteria": {
+                        "test": {
+                            "$description": "Description",
+                            "$desc": "Duplicate",
+                            "$points": [1, 5],
+                        }
+                    }
+                }
+            )
+
+    def test_item_requires_description_and_points(self):
+        with self.assertRaises(CriteriaValidationError) as exc:
+            Criteria({"criteria": {"test": {"$points": [1, 5]}}})
+        self.assertIn("either $description or $desc must be provided", str(exc.exception))
+
+    def test_item_requires_points_or_bonus(self):
+        with self.assertRaises(CriteriaValidationError) as exc:
+            Criteria({"criteria": {"test": {"$description": "Description"}}})
+        self.assertIn("either $points or $bonus must be provided", str(exc.exception))
+
+    def test_section_entries_must_be_mappings(self):
+        with self.assertRaises(CriteriaValidationError):
+            Criteria({"criteria": ["not", "a", "mapping"]})

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,8 +1,6 @@
 from unittest import TestCase
 
-from voluptuous.error import MultipleInvalid
-
-from StudentScore.schema import Criteria
+from StudentScore.schema import Criteria, CriteriaValidationError
 
 
 class TestCriteria(TestCase):
@@ -12,7 +10,7 @@ class TestCriteria(TestCase):
         )
 
     def test_max(self):
-        with self.assertRaises(MultipleInvalid):
+        with self.assertRaises(CriteriaValidationError) as exc:
             Criteria(
                 {
                     "criteria": {
@@ -20,9 +18,10 @@ class TestCriteria(TestCase):
                     }
                 }
             )
+        self.assertIn("criteria/test/$points", str(exc.exception))
 
     def test_below(self):
-        with self.assertRaises(MultipleInvalid):
+        with self.assertRaises(CriteriaValidationError):
             Criteria(
                 {
                     "criteria": {
@@ -32,7 +31,7 @@ class TestCriteria(TestCase):
             )
 
     def test_min(self):
-        with self.assertRaises(MultipleInvalid):
+        with self.assertRaises(CriteriaValidationError):
             Criteria(
                 {
                     "criteria": {
@@ -42,7 +41,7 @@ class TestCriteria(TestCase):
             )
 
     def test_zero(self):
-        with self.assertRaises(MultipleInvalid):
+        with self.assertRaises(CriteriaValidationError):
             Criteria(
                 {
                     "criteria": {
@@ -61,7 +60,7 @@ class TestCriteria(TestCase):
         )
 
     def test_smaller(self):
-        with self.assertRaises(MultipleInvalid):
+        with self.assertRaises(CriteriaValidationError):
             Criteria(
                 {
                     "criteria": {


### PR DESCRIPTION
## Summary
- replace the voluptuous schema definitions with explicit Pydantic models and helper utilities
- surface structured parsing feedback through a dedicated `CriteriaValidationError`
- update the schema unit tests and project dependencies to target Pydantic

## Testing
- PYTHONPATH=. pytest -o addopts="" *(fails: ModuleNotFoundError: No module named 'pydantic' in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f0b6f72c78832bb422ce4fb5c1f9a9